### PR TITLE
Adds filtering by platform.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,85 @@
     <title>Epic Free Games</title>
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <style>
+      /* Wrapper that holds the platform filter and the native DataTables search side-by-side */
+      #dt-toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 8px;
+        margin-bottom: 4px;
+      }
+
+      /* Custom platform dropdown */
+      .platform-filter {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        user-select: none;
+      }
+
+      .platform-filter-selected {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 4px 8px;
+        border: 1px solid #aaa;
+        border-radius: 3px;
+        background: #fff;
+        cursor: pointer;
+        font-size: 0.875rem;
+        white-space: nowrap;
+        min-width: 120px;
+      }
+
+      .platform-filter-selected .pf-arrow {
+        margin-left: auto;
+        font-size: 0.7rem;
+        color: #555;
+      }
+
+      .platform-filter-menu {
+        display: none;
+        position: absolute;
+        top: calc(100% + 2px);
+        left: 0;
+        z-index: 9999;
+        background: #fff;
+        border: 1px solid #aaa;
+        border-radius: 3px;
+        min-width: 100%;
+        box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+        list-style: none;
+        margin: 0;
+        padding: 2px 0;
+      }
+
+      .platform-filter-menu.open {
+        display: block;
+      }
+
+      .platform-filter-menu li {
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        padding: 5px 10px;
+        cursor: pointer;
+        font-size: 0.875rem;
+        white-space: nowrap;
+      }
+
+      .platform-filter-menu li:hover {
+        background: #f0f0f0;
+      }
+
+      .platform-filter-menu li img,
+      .platform-filter-selected img {
+        width: 18px;
+        height: 18px;
+        vertical-align: middle;
+      }
+    </style>
 </head>
 <body>
     <table id="epicGamesTable" class="display" style="width:100%"></table>

--- a/renderTable.js
+++ b/renderTable.js
@@ -1,63 +1,157 @@
 document.addEventListener("DOMContentLoaded", function () {
-  fetch("/EpicFreeGamesList/epic_free_games.json") // Replace with the actual URL of your JSON file
+  const ASSET = "/EpicFreeGamesList/assets/";
+
+  // Platform options definition
+  const PLATFORMS = [
+    {
+      value: "",
+      label: "All",
+      icons: [
+        { src: ASSET + "windows.svg", alt: "PC" },
+        { src: ASSET + "android.svg", alt: "Android" },
+        { src: ASSET + "apple.svg",   alt: "iOS" },
+      ],
+    },
+    {
+      value: "pc",
+      label: "PC",
+      icons: [{ src: ASSET + "windows.svg", alt: "PC" }],
+    },
+    {
+      value: "android",
+      label: "Android",
+      icons: [{ src: ASSET + "android.svg", alt: "Android" }],
+    },
+    {
+      value: "ios",
+      label: "iOS",
+      icons: [{ src: ASSET + "apple.svg", alt: "iOS" }],
+    },
+  ];
+
+  // Currently selected platform value ("" = All)
+  let selectedPlatform = "";
+
+  // Build icons HTML for a platform option
+  function iconsHtml(icons) {
+    return icons
+      .map(i => `<img src="${i.src}" alt="${i.alt}">`)
+      .join("");
+  }
+
+  // Build the full selected-value inner HTML
+  function selectedHtml(option) {
+    return `${iconsHtml(option.icons)}<span class="pf-label">${option.label}</span><span class="pf-arrow">&#9660;</span>`;
+  }
+
+  // Register custom DataTables row filter (runs on every draw)
+  $.fn.dataTable.ext.search.push(function (settings, searchData, dataIndex, rowData) {
+    if (selectedPlatform === "") return true;
+    const rowPlatform = (rowData.platform || "pc").toLowerCase();
+    return rowPlatform === selectedPlatform;
+  });
+
+  fetch("/EpicFreeGamesList/epic_free_games.json")
     .then(response => response.json())
     .then(data => {
-      // Initialize DataTable with the retrieved data
       const dataTable = new DataTable(document.getElementById("epicGamesTable"), {
         data: data,
         pageLength: 100,
         order: [
-          [2, 'desc'],
-          [3, 'desc'],
+          [2, "desc"],
+          [3, "desc"],
         ],
         columns: [
           {
             title: "Title",
             data: "gameTitle",
-            render: function (data, type, row, meta) {
+            render: function (data, type, row) {
               if (type === "display") {
                 return `<a href="${row.epicStoreLink}" target="_blank">${data}</a>`;
               }
               return data;
-            }
+            },
           },
           {
             title: "Platform",
             data: "platform",
-            render: function (data, type, row, meta) {
-              // Default to PC if missing
-              let platform = data ? data.toLowerCase() : "pc";
+            render: function (data, type) {
+              const platform = data ? data.toLowerCase() : "pc";
               let iconPath = "";
               let label = "";
-
               switch (platform) {
                 case "android":
-                  iconPath = "/EpicFreeGamesList/assets/android.svg";
+                  iconPath = ASSET + "android.svg";
                   label = "Android";
                   break;
                 case "ios":
-                  iconPath = "/EpicFreeGamesList/assets/apple.svg";
+                  iconPath = ASSET + "apple.svg";
                   label = "iOS";
                   break;
                 case "pc":
                 default:
-                  iconPath = "/EpicFreeGamesList/assets/windows.svg";
+                  iconPath = ASSET + "windows.svg";
                   label = "PC";
                   break;
               }
-
               return `<img src="${iconPath}" alt="${label}" title="${label}" style="width:20px; height:20px;">`;
-            }
+            },
           },
           {
             title: "Date",
-            data: "freeDate"
+            data: "freeDate",
           },
           {
             title: "Epic Rating",
-            data: "epicRating"
+            data: "epicRating",
           },
-        ]
+        ],
+
+        initComplete: function () {
+          // Build dropdown HTML
+          const menuItems = PLATFORMS.map(opt => {
+            const val = opt.value === "" ? "__all__" : opt.value;
+            return `<li data-platform="${opt.value}">${iconsHtml(opt.icons)}<span>${opt.label}</span></li>`;
+          }).join("");
+
+          const $dropdown = $(`
+            <div class="platform-filter" id="platform-filter">
+              <div class="platform-filter-selected" id="pf-selected">
+                ${selectedHtml(PLATFORMS[0])}
+              </div>
+              <ul class="platform-filter-menu" id="pf-menu">
+                ${menuItems}
+              </ul>
+            </div>
+          `);
+
+          // Wrap the DataTables filter label+input in a flex toolbar
+          const $dtFilter = $("#epicGamesTable_filter");
+          const $toolbar = $('<div id="dt-toolbar"></div>');
+          $dtFilter.before($toolbar);
+          $toolbar.append($dropdown).append($dtFilter);
+
+          // Toggle menu open/closed
+          $("#pf-selected").on("click", function (e) {
+            e.stopPropagation();
+            $("#pf-menu").toggleClass("open");
+          });
+
+          // Select an option
+          $("#pf-menu").on("click", "li", function () {
+            const val = $(this).data("platform");
+            selectedPlatform = val;
+            const match = PLATFORMS.find(p => p.value === val) || PLATFORMS[0];
+            $("#pf-selected").html(selectedHtml(match));
+            $("#pf-menu").removeClass("open");
+            dataTable.draw();
+          });
+
+          // Close on outside click
+          $(document).on("click", function () {
+            $("#pf-menu").removeClass("open");
+          });
+        },
       });
     })
     .catch(error => {


### PR DESCRIPTION
Open combobox → all 4 options visible (All with 3 icons, PC, Android, iOS)

<img width="929" height="925" alt="combo box opened" src="https://github.com/user-attachments/assets/62c3f429-0403-4330-ba19-43cdd884e02c" />


PC → only PC (Windows icon) rows
<img width="929" height="925" alt="PC selected" src="https://github.com/user-attachments/assets/775276e7-cff9-46cb-8540-b24637dadac7" />



Android → only Android (robot icon) rows
<img width="929" height="925" alt="android selected" src="https://github.com/user-attachments/assets/d5434b4c-c25f-41f0-81a4-c4aeef619ed6" />


iOS → only iOS (Apple icon) rows
<img width="929" height="925" alt="iOS selected" src="https://github.com/user-attachments/assets/86d0719d-f178-46c6-97c9-40a2e3f9d60c" />


Return to All → all platforms mixed (PC + Android + iOS rows visible)
<img width="929" height="925" alt="return to all" src="https://github.com/user-attachments/assets/228d86ba-def0-4959-88ed-b1f43dc17b08" />


Android + "Residual" search → exactly 1 row: Residual (Android, 2026-02-19)
<img width="929" height="925" alt="title plus platform search" src="https://github.com/user-attachments/assets/561a44f3-fee5-42d5-9b91-efb857dd0d37" />

